### PR TITLE
update mini_racer and rbtrace for building on latest macOS

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,7 +127,7 @@ GEM
       rake-compiler
     fast_xs (0.8.0)
     fastimage (2.1.5)
-    ffi (1.10.0)
+    ffi (1.15.4)
     flamegraph (0.9.5)
     fspath (3.1.0)
     gc_tracer (1.5.1)
@@ -154,7 +154,7 @@ GEM
     json (2.2.0)
     jwt (2.2.1)
     kgio (2.11.2)
-    libv8 (7.3.492.27.1)
+    libv8-node (16.10.0.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -182,8 +182,8 @@ GEM
     method_source (0.9.2)
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
-    mini_racer (0.2.6)
-      libv8 (>= 6.9.411)
+    mini_racer (0.5.0)
+      libv8-node (~> 16.10.0.0)
     mini_scheduler (0.11.0)
       sidekiq
     mini_sql (0.2.2)
@@ -194,7 +194,7 @@ GEM
       metaclass (~> 0.0.1)
     mock_redis (0.19.0)
     moneta (1.1.1)
-    msgpack (1.2.10)
+    msgpack (1.4.2)
     multi_json (1.13.1)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
@@ -248,7 +248,7 @@ GEM
     openid-redis-store (0.0.2)
       redis
       ruby-openid
-    optimist (3.0.0)
+    optimist (3.0.1)
     parallel (1.17.0)
     parallel_tests (2.28.0)
       parallel
@@ -298,7 +298,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
-    rbtrace (0.4.11)
+    rbtrace (0.4.14)
       ffi (>= 1.0.6)
       msgpack (>= 0.4.3)
       optimist (>= 3.0.0)
@@ -535,4 +535,4 @@ DEPENDENCIES
   webpush
 
 BUNDLED WITH
-   2.1.1
+   2.2.32


### PR DESCRIPTION
mini_racer `0.2.6` has problems with libv8 on Big Sur, so we need to update it to make it usable in dev. `rbtrace` had a similar build problem, solved by updating.