### PR TITLE
use mini_racer ~> 0.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -109,7 +109,7 @@ gem 'mini_scheduler'
 gem 'tilt', require: false
 
 gem 'execjs', require: false
-gem 'mini_racer'
+gem 'mini_racer', '~> 0.4.0'
 gem 'highline', '~> 1.7.0', require: false
 gem 'rack-protection' # security
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,7 +154,7 @@ GEM
     json (2.2.0)
     jwt (2.2.1)
     kgio (2.11.2)
-    libv8-node (16.10.0.0)
+    libv8-node (15.14.0.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -182,8 +182,8 @@ GEM
     method_source (0.9.2)
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
-    mini_racer (0.5.0)
-      libv8-node (~> 16.10.0.0)
+    mini_racer (0.4.0)
+      libv8-node (~> 15.14.0.0)
     mini_scheduler (0.11.0)
       sidekiq
     mini_sql (0.2.2)
@@ -467,7 +467,7 @@ DEPENDENCIES
   memory_profiler
   message_bus
   mini_mime
-  mini_racer
+  mini_racer (~> 0.4.0)
   mini_scheduler
   mini_sql
   mini_suffix


### PR DESCRIPTION
This will use libv8 node 15.14.0 (v8 8.6.395.17). Works on current deployment platform as well as on macOS.